### PR TITLE
Added version report to GTP request and other tidying up in the GTP code

### DIFF
--- a/gongo-benchmark/main.go
+++ b/gongo-benchmark/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func UsageError() {
-	fmt.Fprintf(os.Stderr, "Usage: %v [moveCount]\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %v [[moveCount] gameCount]\n\n", os.Args[0])
 	os.Exit(1)
 }
 

--- a/gtp.go
+++ b/gtp.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -300,8 +301,9 @@ func handle_play(req request) response {
 		return error_("syntax error")
 	}
 
-	ok, _ = req.robot.Play(color, x, y)
+	ok, detail := req.robot.Play(color, x, y)
 	if !ok {
+		fmt.Fprintf(os.Stderr, "Illegal move: %s\n", detail)
 		return error_("illegal move")
 	}
 

--- a/gtp.go
+++ b/gtp.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 )
 
+// Engine-specific constants used in the Go Text Protocol
+const GTPProtocolVersion = "2"
+const GTPEngineName = "Gongo"
+const GTPEngineVersion = "0.1.0"
+
 // The gongo package handles I/O for Go-playing robots written in Go.
 
 // A Go robot is normally implemented as a command-line tool that
@@ -214,13 +219,13 @@ func init() {
 		"known_command":    _known,
 		"komi":             handle_komi,
 		"list_commands":    _list,
-		"name":             func(req request) response { return success("gongo") },
+		"name":             func(req request) response { return success(GTPEngineName) },
 		"play":             handle_play,
-		"protocol_version": func(req request) response { return success("2") },
+		"protocol_version": func(req request) response { return success(GTPProtocolVersion) },
 		"quit":             func(req request) response { return success("") },
 		"showboard":        handle_showboard,
 		"debug":            handle_debug,
-		"version":          func(req request) response { return success("") },
+		"version":          func(req request) response { return success(GTPEngineVersion) },
 	}
 }
 

--- a/gtp_test.go
+++ b/gtp_test.go
@@ -35,8 +35,8 @@ func TestKnownCommand(t *testing.T) {
 
 func TestSimpleCommands(t *testing.T) {
 	checkCommand(t, nil, "protocol_version", "2")
-	checkCommand(t, nil, "name", "gongo")
-	checkCommand(t, nil, "version", "")
+	checkCommand(t, nil, "name", "Gongo")
+	checkCommand(t, nil, "version", "0.1.0")
 }
 
 func TestUnknownCommandError(t *testing.T) {


### PR DESCRIPTION
Making changes to the GTP code to allow easier reuse for other engines.

Commit comment:
Collected simple values together at the top of gtp.go as Constants
Capitalized the name of the engine to "Gongo"
Added a version string initialized to "0.1.0"
